### PR TITLE
Use longer strings in tests

### DIFF
--- a/y-json/tests/patch-y-type.test.ts
+++ b/y-json/tests/patch-y-type.test.ts
@@ -45,7 +45,7 @@ describe('patchYType tests', () => {
 
   it('handles long strings in maps', () => {
     fc.assert(
-      fc.property(fc.string(), fc.string(), (string1, string2) => {
+      fc.property(utils.arbitraryLongString(), utils.arbitraryLongString(), (string1, string2) => {
         const current = { '0': string1 }
         const expected = { '0': string2 }
         const yMap = utils.makeYMap()
@@ -55,9 +55,9 @@ describe('patchYType tests', () => {
     )
   })
 
-  it('handles strings in arrays', () => {
+  it('handles long strings in arrays', () => {
     fc.assert(
-      fc.property(fc.string(), fc.string(), (string1, string2) => {
+      fc.property(utils.arbitraryLongString(), utils.arbitraryLongString(), (string1, string2) => {
         const yArray = utils.makeYArray()
         patchYType(yArray, [string1])
         patchYType(yArray, [string2])

--- a/y-json/tests/utils.ts
+++ b/y-json/tests/utils.ts
@@ -34,6 +34,8 @@ export const arbitraryJSONArray = (): Arbitrary<JsonArray> =>
       return it
     })
 
+export const arbitraryLongString = (): Arbitrary<string> => fc.string({ maxLength: 500 })
+
 export const makeDoc = (): Y.Doc => new Y.Doc()
 
 export const makeYMap = (): Y.Map<unknown> => makeDoc().getMap('test-map')


### PR DESCRIPTION
Long strings are handled differently in jsondiffpatch, we want to make sure we do not miss these cases