### PR TITLE
Improve typing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.wordWrapColumn": 110,
   "editor.codeActionsOnSave": {
     "source.organizeImports": true
   },

--- a/README.md
+++ b/README.md
@@ -7,35 +7,7 @@ Monorepo for packages that facilitate working with arbitrary JSON structures in 
 - `@sanalabs/y-json` Utility functions to mutate Yjs types according to a target JSON object
 - `@sanalabs/json` Utility functions to validate and mutate JSON (patch and merge)
 
-## Principles
-
-### Strict typing (compile-time) and validation (run-time)
-
-- Typed with TypeScript
-- Assertions in runtime to guarantee that no corrupt data gets propagated
-
-### Prohibit `undefined`
-
-`undefined` is not a valid JSON type. However, a property with the value `undefined` in JavaScript is in some contexts considered equivalent to that property not existing. For example:
-
-```js
-JSON.stringify({ prop: undefined }) === JSON.stringify({}) // '{}'
-```
-
-But not always:
-
-```js
-JSON.stringify([undefined]) === JSON.stringify([null]) // What!?
-```
-
-It's actually quite confusing:
-
-```js
-const obj = { a: undefined }
-obj.a === obj.b // true
-```
-
-To increase the strictness and predictability of the code, Collaboration Kit strictly prohibits undefined to be passed around. This is achieved through runtime assertions, see [`json`](https://github.com/sanalabs/collaboration-kit/tree/main/json). If you like this, you may be interested in the typescript compiler option [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes).
+## Notes
 
 ### No excessive package dependencies
 

--- a/json/src/index.ts
+++ b/json/src/index.ts
@@ -1,3 +1,5 @@
 export * from './mutate'
-export * from './validate-json'
-export * from './validate-plain'
+export * from './normalize-json'
+export * from './type-guards-json'
+export * from './type-guards-plain'
+export * from './types'

--- a/json/src/mutate.ts
+++ b/json/src/mutate.ts
@@ -8,7 +8,8 @@ import {
   JsonArray,
   JsonContainer,
   JsonObject,
-  JsonPrimitive,
+  JsonTemplateObject,
+  JsonTemplatePrimitive,
 } from './'
 import { mkErr } from './error'
 
@@ -31,12 +32,6 @@ const keyExists = (obj: any, path: string): boolean => {
 
   return true
 }
-
-type JsonTemplatePrimitive = JsonPrimitive | undefined
-type JsonTemplateObject = { [key: string]: JsonTemplate }
-type JsonTemplateArray = JsonTemplate[]
-type JsonTemplateContainer = JsonTemplateObject | JsonTemplateArray
-type JsonTemplate = JsonTemplatePrimitive | JsonTemplateContainer
 
 function isJsonTemplatePrimitive(val: unknown): val is JsonTemplatePrimitive {
   if (isJsonPrimitive(val)) return true

--- a/json/src/normalize-json.ts
+++ b/json/src/normalize-json.ts
@@ -1,7 +1,15 @@
-import { assertIsPlainContainer, isJsonPrimitive, isPlainArray, isPlainContainer, isPlainObject } from '.'
+import {
+  assertIsPlainContainer,
+  isJsonPrimitive,
+  isPlainArray,
+  isPlainContainer,
+  isPlainObject,
+  JsonContainer,
+  PlainContainer,
+} from '.'
 
 // Deep remove all non-json values
-export function deepNormalizeJson(val: Record<string, unknown> | unknown[]): void {
+export function deepNormalizeJson(val: PlainContainer): asserts val is JsonContainer {
   assertIsPlainContainer(val)
 
   if (isPlainObject(val)) {

--- a/json/src/type-guards-json.ts
+++ b/json/src/type-guards-json.ts
@@ -1,11 +1,14 @@
-import { assertIsPlainArray, assertIsPlainObject, isPlainArray, isPlainObject } from '.'
+import {
+  assertIsPlainArray,
+  assertIsPlainObject,
+  isPlainArray,
+  isPlainObject,
+  Json,
+  JsonArray,
+  JsonObject,
+  JsonPrimitive,
+} from '.'
 import { mkErr } from './error'
-
-export type JsonPrimitive = string | number | boolean | null
-export type JsonObject = { [key: string]: Json }
-export type JsonArray = Json[]
-export type JsonContainer = JsonObject | JsonArray
-export type Json = JsonPrimitive | JsonContainer
 
 export function isJsonPrimitive(val: unknown): val is JsonPrimitive {
   if (typeof val === 'string') return true

--- a/json/src/type-guards-plain.ts
+++ b/json/src/type-guards-plain.ts
@@ -1,6 +1,7 @@
+import { PlainArray, PlainContainer, PlainObject } from '.'
 import { mkErr } from './error'
 
-export function isPlainArray(val: unknown): val is unknown[] {
+export function isPlainArray(val: unknown): val is PlainArray {
   return Array.isArray(val)
 }
 
@@ -8,12 +9,12 @@ export function assertIsString(val: unknown): asserts val is string {
   if (typeof val !== 'string') throw mkErr(val, 'string')
 }
 
-export function assertIsPlainArray(val: unknown): asserts val is unknown[] {
+export function assertIsPlainArray(val: unknown): asserts val is PlainArray {
   if (!isPlainArray(val)) throw mkErr(val, 'array')
 }
 
 // Based on https://github.com/lodash/lodash/blob/master/isPlainObject.js
-export function isPlainObject(val: unknown): val is Record<string, unknown> {
+export function isPlainObject(val: unknown): val is PlainObject {
   if (typeof val !== 'object') return false
   if (val === null) return false
   if (Object.prototype.toString.call(val) !== '[object Object]') return false
@@ -25,14 +26,14 @@ export function isPlainObject(val: unknown): val is Record<string, unknown> {
   return Object.getPrototypeOf(val) === proto
 }
 
-export function assertIsPlainObject(val: unknown): asserts val is Record<string, unknown> {
+export function assertIsPlainObject(val: unknown): asserts val is PlainObject {
   if (!isPlainObject(val)) throw mkErr(val, 'plain object')
 }
 
-export function isPlainContainer(val: unknown): val is Record<string, unknown> | unknown[] {
+export function isPlainContainer(val: unknown): val is PlainContainer {
   return isPlainObject(val) || isPlainArray(val)
 }
 
-export function assertIsPlainContainer(val: unknown): asserts val is Record<string, unknown> | unknown[] {
+export function assertIsPlainContainer(val: unknown): asserts val is PlainContainer {
   if (!isPlainContainer(val)) throw mkErr(val, 'plain object or array')
 }

--- a/json/src/types.ts
+++ b/json/src/types.ts
@@ -1,0 +1,39 @@
+export type PlainObject = Record<string, unknown>
+export type PlainArray = unknown[]
+export type PlainContainer = PlainObject | PlainArray
+
+export type JsonPrimitive = string | number | boolean | null
+export type JsonObject = { [key: string]: Json }
+export type JsonArray = Json[]
+export type JsonContainer = JsonObject | JsonArray
+export type Json = JsonPrimitive | JsonContainer
+
+export type JsonTemplatePrimitive = string | number | boolean | null | undefined
+export type JsonTemplateObject = { [key: string]: JsonTemplate }
+export type JsonTemplateArray = JsonTemplate[]
+export type JsonTemplateContainer = JsonTemplateObject | JsonTemplateArray
+export type JsonTemplate = JsonTemplatePrimitive | JsonTemplateContainer
+
+/**
+ * The value `undefined` is not a valid JSON type, but since JS/TS is inconsistent with how undefined is
+ * treated, this library allows `undefined` as an input value and treats it as a delete operation. The value
+ * `undefined` is never used for insert operations.
+ *
+ * The resason for this is that a property with the value `undefined` in JS/TS is in some contexts considered
+ * equivalent to that property not existing. For example:
+ *
+ * ```js
+ * JSON.stringify({ prop: undefined }) === JSON.stringify({}) // '{}'
+ *
+ * const obj = { a: undefined }
+ * obj.a === obj.b // true
+ * ```
+ *
+ * Handling of `undefined` is not consistent for arrays:
+ *
+ * ```js
+ * JSON.stringify([undefined]) === JSON.stringify([null]) // What!?
+ * ```
+ *
+ * This library fully deletes the `undefined` value in all contexts, including arrays, just like for objects.
+ */

--- a/y-json/package.json
+++ b/y-json/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.175",
-    "fast-json-patch": "^3.1.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "fast-json-patch": "^3.1.0"
   },
   "peerDependencies": {
     "yjs": "^13"

--- a/y-json/src/patch-y-type/index.ts
+++ b/y-json/src/patch-y-type/index.ts
@@ -1,6 +1,12 @@
 import _ from 'lodash'
 import * as Y from 'yjs'
-import { isPlainArray, isPlainObject, JsonArray, JsonObject } from '../../../json/src'
+import {
+  deepNormalizeJson,
+  isPlainArray,
+  isPlainObject,
+  JsonTemplateArray,
+  JsonTemplateObject,
+} from '../../../json/src'
 import { assertIsYMapOrArray, isYArray, isYMap } from '../assertions'
 import { transact } from '../y-utils'
 import * as patchDiffJson from './patch-diff-json'
@@ -16,16 +22,21 @@ type PatchYTypeOptions = {
  */
 export function patchYType(
   yTypeToMutate: Y.Map<unknown>,
-  newState: JsonObject,
+  newState: JsonTemplateObject,
   options?: PatchYTypeOptions,
 ): void
 export function patchYType(
   yTypeToMutate: Y.Array<unknown>,
-  newState: JsonArray,
+  newState: JsonTemplateArray,
   options?: PatchYTypeOptions,
 ): void
-export function patchYType(yTypeToMutate: any, newState: any, options: PatchYTypeOptions = {}): void {
+export function patchYType(
+  yTypeToMutate: Y.Map<unknown> | Y.Array<unknown>,
+  newState: JsonTemplateObject | JsonTemplateArray,
+  options: PatchYTypeOptions = {},
+): void {
   assertIsYMapOrArray(yTypeToMutate, 'object root')
+  deepNormalizeJson(newState)
 
   const isYArrayAndArray = isYArray(yTypeToMutate) && isPlainArray(newState)
   const isYMapAndObject = isYMap(yTypeToMutate) && isPlainObject(newState)

--- a/y-redux/package.json
+++ b/y-redux/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.177",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "fast-json-patch": "^3.1.0"
   }
 }

--- a/y-redux/src/index.ts
+++ b/y-redux/src/index.ts
@@ -1,4 +1,3 @@
-import { patchYType } from '@sanalabs/y-json'
 import _ from 'lodash'
 import { useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector, useStore } from 'react-redux'
@@ -6,6 +5,7 @@ import { Store } from 'redux'
 import { Awareness } from 'y-protocols/awareness.js'
 import * as Y from 'yjs'
 import { JsonObject } from '../../json/src'
+import { patchYType } from '../../y-json/src'
 
 export type BaseAwarenessState = {
   clientId: number
@@ -15,7 +15,7 @@ export type BaseAwarenessState = {
 function sendChanges<T extends JsonObject, RootState>(
   store: Store,
   selectData: (state: RootState) => T | undefined,
-  yMap: Y.Map<T>,
+  yMap: Y.Map<unknown>,
   origin: { origin: string },
 ) {
   return () => {
@@ -39,6 +39,7 @@ function sendChanges<T extends JsonObject, RootState>(
     patchYType(yMap, latestRedux, { origin })
   }
 }
+
 export const SyncYMap = <T extends JsonObject, RootState>({
   yMap,
   setData,
@@ -46,7 +47,7 @@ export const SyncYMap = <T extends JsonObject, RootState>({
   throttleReceiveMs = 200,
   throttleSendMs = 200,
 }: {
-  yMap: Y.Map<T>
+  yMap: Y.Map<unknown>
   setData: (data: T) => any
   selectData: (state: RootState) => T | undefined
   throttleReceiveMs?: number


### PR DESCRIPTION
* Weaken input type from `Json` to `JsonTemplate` to flexibly support how JS and TS handles undefined.
* Fix incorrect typing of yMap in SyncYMap from `Y.Map<T>` to `Y.Map<unknown>`