### PR TITLE
Add failing test

### DIFF
--- a/y-json/src/index.ts
+++ b/y-json/src/index.ts
@@ -1,3 +1,3 @@
 export * from './assertions'
-export { patchYType } from './patch-y-type'
-export { arrayToYArray, objectToYMap, toYType } from './y-utils'
+export * from './patch-y-type'
+export * from './y-utils'

--- a/y-json/tests/to-y-type.test.ts
+++ b/y-json/tests/to-y-type.test.ts
@@ -1,0 +1,9 @@
+import { objectToYMap } from '../src'
+
+describe('to-ymap', () => {
+  it('objectToYMap', () => {
+    const obj = { key1: 1, key2: [{ key21: 'val', key22: [2, 'foo'] }] }
+    const yMap = objectToYMap(obj)
+    expect(yMap.toJSON()).toEqual(obj)
+  })
+})


### PR DESCRIPTION
This is potentially a problem because the failing function objectToYMap is called by unknownToYTypeOrPrimitive which is called by our yjs patching logic.

I suspect that we always hit the case `if (isJsonPrimitive(value)) return value` which is why we don't see any tests failing. If that's the case, we should not invoke the problematic code at all. Perhaps the problematic code should be removed completely?

The root problem is tracked in https://github.com/yjs/yjs/issues/207 and basically YTypes cannot receive edit operations if they are not attached to a YDoc.