### PR TITLE
Export the function unknownToYTypeOrPrimitive.

### DIFF
--- a/packages/y-json/package.json
+++ b/packages/y-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanalabs/y-json",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "description": "Transform Yjs Shared Types according to a JSON object",
   "license": "ISC",
   "main": "dist/cjs/index.js",

--- a/packages/y-json/src/index.ts
+++ b/packages/y-json/src/index.ts
@@ -1,3 +1,3 @@
 export * from './assertions'
 export { patchYJson, replaceYType } from './patch-y-type'
-export { arrayToYArray, objectToYMap, toYType } from './y-utils'
+export { arrayToYArray, objectToYMap, toYType, unknownToYTypeOrPrimitive } from './y-utils'


### PR DESCRIPTION
This function is needed in `yarn-project-root/domain/collaboration/serialization/replace-y-doc.ts` in Sana.

@ViktorQvarfordt I noticed that the newest version of the `y-json` package that has been checked into the repo is `0.1.18`, but the version used in Sana is `0.1.19`. Do you know what the diff between `0.1.18` and `0.1.19` might be?